### PR TITLE
allow abbreviation of hop commands

### DIFF
--- a/hop/__main__.py
+++ b/hop/__main__.py
@@ -18,8 +18,11 @@ def main():
     parser = argparse.ArgumentParser()
     subparsers = parser.add_subparsers(dest='subparser_name', metavar='')
 
-    for alias, cls in commands.items():
+    for alias, cls in sorted(commands.items()):
         cls.setup_command(subparsers)
+
+        if len(sys.argv) > 1 and alias.startswith(sys.argv[1]):
+            sys.argv[1] = alias
 
     if len(sys.argv) == 1 or sys.argv[-1] in ['-h', '--help']:
         # print directive before showing help message


### PR DESCRIPTION
Allow the user to pass in abbreviations for all built-in and configured
commands. i.e.:
  hop t   -> hop should recognize this as `hop to`
  hop li  -> `hop list`

if a user has a command called `start` configured for a project, then
any of the following should be valid:
  hop s
  hop st
  hop sta
  hop star
  hop start

if the user gives an ambiguous abbreviation, the first available command
that it matches alphabetically will be used. So, for example, if you do
`hop e`, hop will do `hop edit`, not `hop env`, unless the user has
configured a command that starts with `e` that comes before `edit`
alphabetically.

argparse has this capability built-in for the main parser, but not for
subparsers, hence why i'm doing it this way. see
https://stackoverflow.com/questions/47222276/